### PR TITLE
issue-16 Fixed 'sleep' subcommand

### DIFF
--- a/stream-loader.py
+++ b/stream-loader.py
@@ -33,7 +33,7 @@ except:
 __all__ = []
 __version__ = 1.0
 __date__ = '2018-10-29'
-__updated__ = '2019-02-01'
+__updated__ = '2019-03-29'
 
 SENZING_PRODUCT_ID = "5001"  # See https://github.com/Senzing/knowledge-base/blob/master/lists/senzing-product-ids.md
 log_format = '%(asctime)s %(message)s'
@@ -142,7 +142,7 @@ configuration_locator = {
         "cli": "senzing-dir"
     },
     "sleep_time": {
-        "default": 600,
+        "default": 0,
         "env": "SENZING_SLEEP_TIME",
         "cli": "sleep-time"
     },
@@ -180,7 +180,7 @@ def get_parser():
     subparser_1.add_argument("--threads-per-process", dest="threads_per_process", metavar="SENZING_THREADS_PER_PROCESS", help="Number of threads per process. Default: 4")
 
     subparser_2 = subparsers.add_parser('sleep', help='Do nothing but sleep. For Docker testing.')
-    subparser_2.add_argument("--sleep-time", dest="sleep_time", metavar="SENZING_SLEEP_TIME", help="Sleep time in seconds. DEFAULT: 600")
+    subparser_2.add_argument("--sleep-time", dest="sleep_time", metavar="SENZING_SLEEP_TIME", help="Sleep time in seconds. DEFAULT: 0 (infinite)")
 
 #    subparser_3 = subparsers.add_parser('stdin', help='Read JSON Lines from STDIN.')
 #    subparser_3.add_argument("--data-source", dest="data_source", metavar="SENZING_DATA_SOURCE", help="Used when JSON line does not have a `DATA_SOURCE` key.")
@@ -249,6 +249,7 @@ message_dictionary = {
     "127": "Monitor: {0}",
     "128": "Sleeping {0} seconds.",
     "129": "{0} is running.",
+    "130": "Sleeping infinitely.",
     "197": "Version: {0}  Updated: {1}",
     "198": "For information on warnings and errors, see https://github.com/Senzing/stream-loader#errors",
     "199": "{0}",
@@ -350,7 +351,8 @@ def get_g2project_ini_filename(args_dictionary):
 
     # If file not found, return error.
 
-    exit_error(406)
+    logging.warn(message_warn(406))
+    return None
 
 
 def get_configuration(args):
@@ -1543,13 +1545,20 @@ def do_sleep(args):
 
     # Pull values from configuration.
 
-    sleep_time = int(config.get('sleep_time'))
+    sleep_time = config.get('sleep_time')
 
     # Sleep
+    
+    if sleep_time > 0: 
+        logging.info(message_info(128, sleep_time))
+        time.sleep(sleep_time)
 
-    logging.info(message_info(128, sleep_time))
-    time.sleep(sleep_time)
-
+    else:
+        sleep_time = 3600
+        while True:
+            logging.info(message_info(130))
+            time.sleep(sleep_time)
+        
     # Epilog.
 
     logging.info(exit_template(config))


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

ISSUE-16

## Why was change needed

The `sleep` subcommand was choking on a missing G2Project.ini, which it shouldn't even be checking.