### PR TITLE
Properly qualified an exception name

### DIFF
--- a/stream-loader.py
+++ b/stream-loader.py
@@ -1566,7 +1566,7 @@ def get_g2_product(config):
     try:
         result = G2Product()
         result.init(product_name, config.get('g2project_ini'), config.get('debug'))
-    except G2ModuleException as err:
+    except G2Exception.G2ModuleException as err:
         exit_error(504, config.get('g2project_ini'), err)
     return result
 


### PR DESCRIPTION
to avoid an exception about the exception... name

## Which issue does this address

ISSUE-25

## Why was change needed

The unqualified name would cause an exception when hit

## What does change improve

no more exception
