### PR TITLE
Issue 35.dockter.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,12 @@ This repository assumes a working knowledge of:
 * **SENZING_DEBUG** -
   Enable debug information. Values: 0=no debug; 1=debug. Default: 0.
 * **SENZING_DIR** -
-  Location of Senzing libraries. Default: "/opt/senzing".
+  Path on the local system where
+  [Senzing_API.tgz](https://s3.amazonaws.com/public-read-access/SenzingComDownloads/Senzing_API.tgz)
+  has been extracted.
+  See [Create SENZING_DIR](#create-senzing_dir).
+  No default.
+  Usually set to "/opt/senzing".
 * **SENZING_ENTITY_TYPE** -
   Default "ENTITY_TYPE" value for incoming records.
 * **SENZING_ENTRYPOINT_SLEEP** -

--- a/README.md
+++ b/README.md
@@ -92,10 +92,13 @@ This repository assumes a working knowledge of:
 
 * **SENZING_DATA_SOURCE** -
   Default "DATA_SOURCE" value for incoming records.
+  No default.
 * **SENZING_DATABASE_URL** -
-  Database URI in the form: `${DATABASE_PROTOCOL}://${DATABASE_USERNAME}:${DATABASE_PASSWORD}@${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_DATABASE}`  
+  Database URI in the form: `${DATABASE_PROTOCOL}://${DATABASE_USERNAME}:${DATABASE_PASSWORD}@${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_DATABASE}`
+  Default:  [internal SQLite database]  
 * **SENZING_DEBUG** -
-  Enable debug information. Values: 0=no debug; 1=debug. Default: 0.
+  Enable debug information. Values: 0=no debug; 1=debug.
+  Default: 0.
 * **SENZING_DIR** -
   Path on the local system where
   [Senzing_API.tgz](https://s3.amazonaws.com/public-read-access/SenzingComDownloads/Senzing_API.tgz)
@@ -105,6 +108,7 @@ This repository assumes a working knowledge of:
   Usually set to "/opt/senzing".
 * **SENZING_ENTITY_TYPE** -
   Default "ENTITY_TYPE" value for incoming records.
+  No default.
 * **SENZING_ENTRYPOINT_SLEEP** -
   Sleep, in seconds, before executing.
   0 for sleeping infinitely.
@@ -114,34 +118,48 @@ This repository assumes a working knowledge of:
   Default: [not-set].  
 * **SENZING_INPUT_URL** -
   URL of source file.
+  No default.
 * **SENZING_KAFKA_BOOTSTRAP_SERVER** -
-  Hostname and port of Kafka server.  Default: "localhost:9092"
+  Hostname and port of Kafka server.
+  Default: "localhost:9092"
 * **SENZING_KAFKA_GROUP** -
-  Kafka group. Default: "senzing-kafka-group"
+  Kafka group.
+  Default: "senzing-kafka-group"
 * **SENZING_KAFKA_TOPIC** -
-  Kafka topic. Default: "senzing-kafka-topic"
+  Kafka topic.
+  Default: "senzing-kafka-topic"
 * **SENZING_LOG_LEVEL** -
-  Level of logging. {notset, debug, info, warning, error, critical}. Default: info
+  Level of logging. {notset, debug, info, warning, error, critical}.
+  Default: info
 * **SENZING_MONITORING_PERIOD** -
-  Time, in seconds, between monitoring log records. Default: 300
+  Time, in seconds, between monitoring log records.
+  Default: 300
 * **SENZING_PROCESSES** -
-  Number of processes to allocated for processing. Default: 1
+  Number of processes to allocated for processing.
+  Default: 1
 * **SENZING_QUEUE_MAX** -
-  Maximum items for internal queue. Default: 10
+  Maximum items for internal queue.
+  Default: 10
+* **SENZING_RABBITMQ_HOST** -
+  Host name of the RabbitMQ exchange.
+  Default: "localhost:5672"
+* **SENZING_RABBITMQ_PASSWORD** -
+  The password for the RabbitMQ queue.
+  Default: "bitnami"
+* **SENZING_RABBITMQ_QUEUE** -
+  Name of the RabbitMQ queue used for communication.
+  Default: "senzing-rabbitmq-queue"
+* **SENZING_RABBITMQ_USERNAME** -
+  The username for the RabbitMQ queue.
+  Default: "user"
 * **SENZING_SLEEP_TIME** -
-  Amount of time to sleep, in seconds for `stream-loader.py sleep` subcommand. Default: 600.
+  Amount of time to sleep, in seconds for `stream-loader.py sleep` subcommand.
+  Default: 600.
 * **SENZING_SUBCOMMAND** -
   Identify the subcommand to be run. See `stream-loader.py --help` for complete list.  
 * **SENZING_THREADS_PER_PROCESS** -
-  Number of threads per process to allocate for processing. Default: 4
-* **SENZING_RABBITMQ_HOST** -
-  Host name of the RabbitMQ exchange
-* **SENZING_RABBITMQ_QUEUE** -
-  Name of the RabbitMQ queue to create/connect with
-* **SENZING_RABBITMQ_USERNAME** -
-  The username for the RabbitMQ queue
-* **SENZING_RABBITMQ_PASSWORD** -
-  The password for the RabbitMQ queue
+  Number of threads per process to allocate for processing.
+  Default: 4
   
 1. To determine which configuration parameters are use for each `<subcommand>`, run:
 
@@ -253,7 +271,7 @@ The following software programs need to be installed:
 ## Examples
 
 1. Examples of use:
-    1. [docker-compose-stream-loader-kafka-demo](https://github.com/Senzing/docker-compose-stream-loader-kafka-demo)
+    1. [docker-compose-demo](https://github.com/Senzing/docker-compose-demo)
     1. [kubernetes-demo](https://github.com/Senzing/kubernetes-demo)
     1. [rancher-demo](https://github.com/Senzing/rancher-demo/tree/master/docs/db2-cluster-demo.md)
 

--- a/stream-loader.py
+++ b/stream-loader.py
@@ -635,10 +635,10 @@ class KafkaProcess(multiprocessing.Process):
 
         # Start threads.
 
-        for thread in self.adminThreads:
+        for thread in self.threads:
             thread.start()
 
-        for thread in self.threads:
+        for thread in self.adminThreads:
             thread.start()
 
         # Collect inactive threads.
@@ -676,10 +676,10 @@ class KafkaTestProcess(multiprocessing.Process):
 
         # Start threads.
 
-        for thread in self.adminThreads:
+        for thread in self.threads:
             thread.start()
 
-        for thread in self.threads:
+        for thread in self.adminThreads:
             thread.start()
 
         # Collect inactive threads.
@@ -717,10 +717,10 @@ class RabbitMQProcess(multiprocessing.Process):
 
         # Start threads.
 
-        for thread in self.adminThreads:
+        for thread in self.threads:
             thread.start()
 
-        for thread in self.threads:
+        for thread in self.adminThreads:
             thread.start()
 
         # Collect inactive threads.
@@ -758,10 +758,10 @@ class RabbitMQTestProcess(multiprocessing.Process):
 
         # Start threads.
 
-        for thread in self.adminThreads:
+        for thread in self.threads:
             thread.start()
 
-        for thread in self.threads:
+        for thread in self.adminThreads:
             thread.start()
 
         # Collect inactive threads.
@@ -1364,6 +1364,10 @@ class MonitorThread(threading.Thread):
         # Sleep-monitor loop.
 
         active_workers = len(self.workers)
+        for worker in self.workers:
+            if not worker.is_alive():
+                active_workers -= 1
+
         while active_workers > 0:
 
             time.sleep(sleep_time)
@@ -1452,6 +1456,10 @@ class MonitorTestThread(threading.Thread):
         # Sleep-monitor loop.
 
         active_workers = len(self.workers)
+        for worker in self.workers:
+            if not worker.is_alive():
+                active_workers -= 1
+
         while active_workers > 0:
 
             time.sleep(sleep_time)
@@ -1910,10 +1918,10 @@ def do_kafka(args):
 
     # Start threads for master process.
 
-    for thread in adminThreads:
+    for thread in threads:
         thread.start()
 
-    for thread in threads:
+    for thread in adminThreads:
         thread.start()
 
     # Start additional processes. (if 2 or more processes are requested.)
@@ -2019,10 +2027,10 @@ def do_rabbitmq(args):
 
     # Start threads for master process.
 
-    for thread in adminThreads:
+    for thread in threads:
         thread.start()
 
-    for thread in threads:
+    for thread in adminThreads:
         thread.start()
 
     # Start additional processes. (if 2 or more processes are requested.)

--- a/stream-loader.py
+++ b/stream-loader.py
@@ -310,6 +310,7 @@ message_dictionary = {
     "149": "   Minimum recommended memory: {0:.1f} GB",
     "150": "Insertion test: {0} records inserted in {1}ms with an average of {2:.2f}ms per insert.",
     "151": "For database tuning help, see: https://senzing.zendesk.com/hc/en-us/sections/360000386433-Technical-Database",
+    "152": "Sleeping {0} seconds before deploying administrative threads.",
     "197": "Version: {0}  Updated: {1}",
     "198": "For information on warnings and errors, see https://github.com/Senzing/stream-loader#errors",
     "199": "{0}",
@@ -1921,6 +1922,15 @@ def do_kafka(args):
     for thread in threads:
         thread.start()
 
+    # Sleep, if requested.
+
+    sleep_time = config.get('sleep_time')
+    if sleep_time > 0:
+        logging.info(message_info(152, sleep_time))
+        time.sleep(sleep_time)
+
+    # Start administrative threads for master process.
+
     for thread in adminThreads:
         thread.start()
 
@@ -2029,6 +2039,15 @@ def do_rabbitmq(args):
 
     for thread in threads:
         thread.start()
+
+    # Sleep, if requested.
+
+    sleep_time = config.get('sleep_time')
+    if sleep_time > 0:
+        logging.info(message_info(152, sleep_time))
+        time.sleep(sleep_time)
+
+    # Start administrative threads for master process.
 
     for thread in adminThreads:
         thread.start()


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

ISSUE-35
## Why was change needed
When threads exited, the monitoring threads would continue.  So the python script never exited.  ...and the docker-compose formation wouldn't "reboot" the image.   

This was made apparent with RabbitMQ and SQLite.   SQLite was initialized so fast that it tried to contact RabbitMQ before it was ready.  The thread errored and exited.  But because the Monitoring thread continued docker-compose didn't know that the image needed to be restarted.

## What does change improve

This change does 2 things:

1. The monitoring thread exits when there are no active "worker" threads.
1. The administrative threads (monitoring) can be delayed by specifiying a "sleep" time before the monitoring threads are started.   This allows worker threads to error before the administration threads count them as "active". 
