### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ configparser
 confluent-kafka
 psutil
 pika
+boto3


### PR DESCRIPTION
boto3 is now a dependency of stream-loader

# Pull request questions

## Why was change needed

Since stream-loader started to support SQS it now has a dependency on boto3. This is not standard so should be declared in the requirements.txt file

## What does change improve

Prevents build failures
