### PR TITLE
Issue 173.jadair.1

### DIFF
--- a/stream-loader.py
+++ b/stream-loader.py
@@ -2647,6 +2647,22 @@ def delay(config):
             logging.info(message_info(120, delay_in_seconds))
             time.sleep(delay_in_seconds)
 
+def import_plugins():
+    try:
+        global Governor
+        senzing_governor = importlib.import_module("senzing_governor")
+        Governor = senzing_governor.Governor
+        logging.info(message_info(180, senzing_governor.__file__))
+    except ImportError:
+        pass
+
+    try:
+        global InfoFilter
+        senzing_info_filter = importlib.import_module("senzing_info_filter")
+        InfoFilter = senzing_info_filter
+        logging.info(message_info(181, senzing_info_filter.__file__))
+    except ImportError:
+        pass
 
 def entry_template(config):
     ''' Format of entry message. '''
@@ -2961,22 +2977,7 @@ def common_prolog(config):
     delay(config)
 
     # Import plugins
-
-    try:
-        global Governor
-        senzing_governor = importlib.import_module("senzing_governor")
-        Governor = senzing_governor.Governor
-        logging.info(message_info(180, senzing_governor.__file__))
-    except ImportError:
-        pass
-
-    try:
-        global InfoFilter
-        senzing_info_filter = importlib.import_module("senzing_info_filter")
-        InfoFilter = senzing_info_filter
-        logging.info(message_info(181, senzing_info_filter.__file__))
-    except ImportError:
-        pass
+    import_plugins()
 
     # Write license information to log.
 

--- a/stream-loader.py
+++ b/stream-loader.py
@@ -2659,7 +2659,7 @@ def import_plugins():
     try:
         global InfoFilter
         senzing_info_filter = importlib.import_module("senzing_info_filter")
-        InfoFilter = senzing_info_filter
+        InfoFilter = senzing_info_filter.InfoFilter
         logging.info(message_info(181, senzing_info_filter.__file__))
     except ImportError:
         pass
@@ -2977,6 +2977,7 @@ def common_prolog(config):
     delay(config)
 
     # Import plugins
+
     import_plugins()
 
     # Write license information to log.

--- a/stream-loader.py
+++ b/stream-loader.py
@@ -27,6 +27,7 @@ import subprocess
 import sys
 import threading
 import time
+import importlib
 
 # Import Senzing libraries.
 
@@ -2959,6 +2960,24 @@ def common_prolog(config):
 
     delay(config)
 
+    # Import plugins
+
+    try:
+        global Governor
+        senzing_governor = importlib.import_module("senzing_governor")
+        Governor = senzing_governor.Governor
+        logging.info(message_info(180, senzing_governor.__file__))
+    except ImportError:
+        pass
+
+    try:
+        global InfoFilter
+        senzing_info_filter = importlib.import_module("senzing_info_filter")
+        InfoFilter = senzing_info_filter
+        logging.info(message_info(181, senzing_info_filter.__file__))
+    except ImportError:
+        pass
+
     # Write license information to log.
 
     log_license(config)
@@ -3495,22 +3514,6 @@ if __name__ == "__main__":
 
     signal.signal(signal.SIGTERM, bootstrap_signal_handler)
     signal.signal(signal.SIGINT, bootstrap_signal_handler)
-
-    # Import plugins
-
-    try:
-        import senzing_governor
-        from senzing_governor import Governor
-        logging.info(message_info(180, senzing_governor.__file__))
-    except ImportError:
-        pass
-
-    try:
-        import senzing_info_filter
-        from senzing_info_filter import InfoFilter
-        logging.info(message_info(181, senzing_info_filter.__file__))
-    except ImportError:
-        pass
 
     # Parse the command line arguments.
 


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

Issue number: #173 

## Why was change needed

The first time a docker formation was brought up (or if the senzing governor was deleted) stream-loader would try to impot senzing_governor before it was copied down by docker-init-container