### PR TITLE
Handle long running add_record() calls with RabbitMQ

### DIFF
--- a/stream-loader.py
+++ b/stream-loader.py
@@ -2004,7 +2004,6 @@ class ReadRabbitMQWriteG2WithInfoThread(WriteG2Thread):
             except Exception as err:
                 logging.info(message_debug(557, message_str, err))
                 if self.add_to_failure_queue(str(message_str)):
-#                    channel.basic_ack(delivery_tag=method.delivery_tag)
                     self.setup_ack(delivery_tag)
                 return
 
@@ -2033,7 +2032,7 @@ class ReadRabbitMQWriteG2WithInfoThread(WriteG2Thread):
                     self.config['counter_processed_records'] += 1
 
             # After importing into Senzing, tell RabbitMQ we're done with message. All the records are loaded or moved to the failure queue
-#            channel.basic_ack(delivery_tag=method.delivery_tag)
+
             self.setup_ack(delivery_tag)
 
     def setup_ack(self, delivery_tag):

--- a/stream-loader.py
+++ b/stream-loader.py
@@ -1800,7 +1800,7 @@ class ReadRabbitMQWriteG2Thread(WriteG2Thread):
                     time.sleep(60)
                 except pika.exceptions.ConnectionClosed as err:
                     logging.info(message_info(131, threading.current_thread().name), err)
-                    logging.info("!!!!!!!!!!!!!!!!!!!!!! RabbitMQ Channel closed on add_callback_threadsafe(), sleeping for 60s then trying to reconnect")
+                    logging.info("!!!!!!!!!!!!!!!!!!!!!! RabbitMQ Connection closed on add_callback_threadsafe(), sleeping for 60s then trying to reconnect")
                     time.sleep(60)
                 except Exception as err:
                     logging.info(message_info(880, err, "channel.start_consuming()"))

--- a/stream-loader.py
+++ b/stream-loader.py
@@ -1796,7 +1796,6 @@ class ReadRabbitMQWriteG2Thread(WriteG2Thread):
             channel.basic_ack(delivery_tag)
         else:
             # Channel is already closed, so we can't ACK this message;
-            # log and/or do something that makes sense for your app in this case.
             pass
 
     def run(self):

--- a/stream-loader.py
+++ b/stream-loader.py
@@ -751,7 +751,8 @@ message_dictionary = {
     "127": "Monitor: {0}",
     "128": "Adding JSON to info queue: {0}",
     "129": "{0} is running.",
-    "130": "RabbitMQ channel closed by the broker. Shutting down thread {0}. Error: {1}",
+    "130": "RabbitMQ channel closed by the broker. Thread {0}. Error: {1}",
+    "131": "RabbitMQ connection closed by the broker. Thread {0}. Error: {1}",
     "140": "System Resources:",
     "141": "    Physical cores: {0}",
     "142": "     Logical cores: {0}",
@@ -1788,14 +1789,34 @@ class ReadRabbitMQWriteG2Thread(WriteG2Thread):
 
             # After importing into Senzing, tell RabbitMQ we're done with message. All the records are loaded or moved to the failure queue
 
-            cb = functools.partial(self.ack_message, channel, delivery_tag)
-            connection.add_callback_threadsafe(cb)
+            # we may not need to do this, rabbit mq might have to resend the message anyway when the connection fails?
+            while True:
+                try:
+                    cb = functools.partial(self.ack_message, channel, delivery_tag)
+                    connection.add_callback_threadsafe(cb)
+                except pika.exceptions.ChannelClosed as err:
+                    logging.info(message_info(130, threading.current_thread().name), err)
+                    logging.info("!!!!!!!!!!!!!!!!!!!!!! RabbitMQ Channel closed on add_callback_threadsafe(), sleeping for 60s then trying to reconnect")
+                    time.sleep(60)
+                except pika.exceptions.ConnectionClosed as err:
+                    logging.info(message_info(131, threading.current_thread().name), err)
+                    logging.info("!!!!!!!!!!!!!!!!!!!!!! RabbitMQ Channel closed on add_callback_threadsafe(), sleeping for 60s then trying to reconnect")
+                    time.sleep(60)
+                except Exception as err:
+                    logging.info(message_info(880, err, "channel.start_consuming()"))
+                    logging.info("Unknown exception on add_callback_threadsafe() of type " + type(err).__name__)
+                    logging.info("!!!!!!!!!!!!!!!!!!!!!! RabbitMQ Connection/Channel closed on add_callback_threadsafe(), sleeping for 60s then trying to reconnect")
+                    time.sleep(60)
+                    #exit_error(880, err, "channel.start_consuming()")
+                break
+                
 
     def ack_message(self, channel, delivery_tag):
         if channel.is_open:
             channel.basic_ack(delivery_tag)
         else:
             # Channel is already closed, so we can't ACK this message;
+            # log and/or do something that makes sense for your app in this case.
             pass
 
     def run(self):
@@ -1820,31 +1841,39 @@ class ReadRabbitMQWriteG2Thread(WriteG2Thread):
         self.record_queue = queue.Queue()
 
         # Connect to RabbitMQ queue.
-        try:
-            credentials = pika.PlainCredentials(rabbitmq_username, rabbitmq_password)
-            connection = pika.BlockingConnection(pika.ConnectionParameters(host=rabbitmq_host, port=rabbitmq_port, credentials=credentials, heartbeat=rabbitmq_heartbeat))
-            channel = connection.channel()
-            channel.queue_declare(queue=rabbitmq_queue, passive=rabbitmq_passive_declare)
-            channel.basic_qos(prefetch_count=rabbitmq_prefetch_count)
-            channel.basic_consume(on_message_callback=self.callback, queue=rabbitmq_queue)
-        except pika.exceptions.AMQPConnectionError as err:
-            exit_error(412, "No exchange, consumer", rabbitmq_queue, "No routing key, consumer", err, rabbitmq_host)
-        except Exception as err:
-            exit_error(880, err, "creating RabbitMQ channel")
-        except BaseException as err:
-            exit_error(561, err)
+        while True:
+            try:
+                credentials = pika.PlainCredentials(rabbitmq_username, rabbitmq_password)
+                connection = pika.BlockingConnection(pika.ConnectionParameters(host=rabbitmq_host, port=rabbitmq_port, credentials=credentials, heartbeat=rabbitmq_heartbeat))
+                channel = connection.channel()
+                channel.queue_declare(queue=rabbitmq_queue, passive=rabbitmq_passive_declare)
+                channel.basic_qos(prefetch_count=rabbitmq_prefetch_count)
+                channel.basic_consume(on_message_callback=self.callback, queue=rabbitmq_queue)
+            except pika.exceptions.AMQPConnectionError as err:
+                exit_error(412, "No exchange, consumer", rabbitmq_queue, "No routing key, consumer", err, rabbitmq_host)
+            except Exception as err:
+                exit_error(880, err, "creating RabbitMQ channel")
+            except BaseException as err:
+                exit_error(561, err)
 
-        # Start worker thread
-        worker_thread = threading.Thread(target=self.worker, args=(connection, channel))
-        worker_thread.start()
+            # Start worker thread
+            worker_thread = threading.Thread(target=self.worker, args=(connection, channel))
+            worker_thread.start()
 
-        # Start consuming.
-        try:
-            channel.start_consuming()
-        except pika.exceptions.ChannelClosed as err:
-            logging.info(message_info(130, threading.current_thread().name), err)
-        except Exception as err:
-            exit_error(880, err, "channel.start_consuming()")
+            # Start consuming.
+            try:
+                channel.start_consuming()
+            except pika.exceptions.ChannelClosed as err:
+                logging.info(message_info(130, threading.current_thread().name), err)
+            except pika.exceptions.ConnectionClosed as err:
+                logging.info(message_info(131, threading.current_thread().name), err)
+            except Exception as err:
+                logging.info(message_info(880, err, "channel.start_consuming()"))
+                logging.info("Unknown exception on start_consuming() of type " + type(err).__name__)
+                #exit_error(880, err, "channel.start_consuming()")
+            logging.info("!!!!!!!!!!!!!!!!!!!!!! RabbitMQ Connection/Channel closed on start_consuming(), sleeping for 30s then trying to reconnect")
+            time.sleep(30)
+            
 
 # -----------------------------------------------------------------------------
 # Class: ReadRabbitMQWriteG2WithInfoThread

--- a/stream-loader.py
+++ b/stream-loader.py
@@ -1806,7 +1806,7 @@ class ReadRabbitMQWriteG2Thread(WriteG2Thread):
     def ack_message(self, delivery_tag):
         try:
             self.channel.basic_ack(delivery_tag)
-        except BaseException as err:
+        except Exception as err:
             logging.info(message_info(132, threading.current_thread().name, err))
 
     def run(self):
@@ -1842,8 +1842,6 @@ class ReadRabbitMQWriteG2Thread(WriteG2Thread):
             exit_error(412, "N/A (consumer)", rabbitmq_queue, "N/A (consumer)", err, rabbitmq_host)
         except Exception as err:
             exit_error(880, err, "creating RabbitMQ channel")
-        except BaseException as err:
-            exit_error(561, err)
 
         # Start worker thread.
 
@@ -1876,8 +1874,6 @@ class ReadRabbitMQWriteG2Thread(WriteG2Thread):
                 logging.info(message_info(412, "N/A (consumer)", rabbitmq_queue, "N/A (consumer)", err, rabbitmq_host))
             except Exception as err:
                 logging.info(message_info(880, err, "creating RabbitMQ channel"))
-            except BaseException as err:
-                logging.info(message_info(561, err))
 
     def connect(self, credentials, host_name, port, queue_name, heartbeat, prefetch_count):
         rabbitmq_passive_declare = self.config.get("rabbitmq_use_existing_entities")
@@ -2104,8 +2100,6 @@ class ReadRabbitMQWriteG2WithInfoThread(WriteG2Thread):
             exit_error(412, str(exchange), queue_name, str(routing_key), err, host_name)
         except Exception as err:
             exit_error(880, err, "creating RabbitMQ info channel")
-        except BaseException as err:
-            exit_error(410, exchange, queue, routing_key, err)
 
         return channel
 

--- a/stream-loader.py
+++ b/stream-loader.py
@@ -1850,7 +1850,6 @@ class ReadRabbitMQWriteG2Thread(WriteG2Thread):
         worker_thread = threading.Thread(target=self.worker)
         worker_thread.start()
 
-
         # Start consuming.
 
         while True:


### PR DESCRIPTION

## Which issue does this address

Issue number: #183

## Why was change needed

If add_record() would run for more than a minute it would risk a heartbeat timeout. Restructuring code let the callback thread return to servicing the ioloop and defer add_record() to a worker thread.

