### PR TITLE
Issue 217.jadair.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.7.6] - TBD
+## [1.7.6] - 2021-05-26
 
 ### Changed in 1.7.6
 
+- SQS based loads now only remove the record from the queue if it was successfully loaded to Senzing, permitting failed records to go to the dead letter queue, if configured.
 - RabbitMQ virtual host is now a settable parameter.
 
 ## [1.7.5] - 2021-04-05


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

Issue number: #217 

## Why was change needed

For SQS based loads, stream-loader was always removing the record from the queue. This prevented records that failed to load from going to the dead letter queue.

## What does change improve

Only remove a record from and SQS queue if the load was successful.
