### PR TITLE
Adding indexes onto the connect return value to get the channel

### DIFF
--- a/stream-loader.py
+++ b/stream-loader.py
@@ -2321,7 +2321,7 @@ class ReadRabbitMQWriteG2WithInfoThread(WriteG2Thread):
 
             # sleep to give the broker time to come back
             time.sleep(retry_delay)
-            self.failure_channel = self.connect(self.failure_credentials, self.rabbitmq_failure_host, self.rabbitmq_failure_port, self.rabbitmq_failure_virtual_host, self.rabbitmq_failure_queue, self.rabbitmq_heartbeat, self.rabbitmq_failure_exchange, self.rabbitmq_failure_routing_key)
+            self.failure_channel = self.connect(self.failure_credentials, self.rabbitmq_failure_host, self.rabbitmq_failure_port, self.rabbitmq_failure_virtual_host, self.rabbitmq_failure_queue, self.rabbitmq_heartbeat, self.rabbitmq_failure_exchange, self.rabbitmq_failure_routing_key)[1]
 
         return result
 
@@ -2357,7 +2357,7 @@ class ReadRabbitMQWriteG2WithInfoThread(WriteG2Thread):
 
             # sleep to give the broker time to come back
             time.sleep(retry_delay)
-            self.info_channel = self.connect(self.info_credentials, self.rabbitmq_info_host, self.rabbitmq_info_port, self.rabbitmq_info_virtual_host, self.rabbitmq_info_queue, self.rabbitmq_heartbeat, self.rabbitmq_info_exchange, self.rabbitmq_info_routing_key)
+            self.info_channel = self.connect(self.info_credentials, self.rabbitmq_info_host, self.rabbitmq_info_port, self.rabbitmq_info_virtual_host, self.rabbitmq_info_queue, self.rabbitmq_heartbeat, self.rabbitmq_info_exchange, self.rabbitmq_info_routing_key)[1]
 
     def callback(self, _channel, method, _header, body):
         logging.debug(message_debug(903, threading.current_thread().name, body))


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

Issue number: #253 

## Why was change needed

The stream loader would not reconnect after the connections to the info and failure queues timed out.

## What does change improve

Reconnection after connection timeout for info and failure queues
